### PR TITLE
feat:article-user-screen 記事・ユーザー画面の作成

### DIFF
--- a/BuildTools/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/BuildTools/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/QiitaSwiftClient.xcodeproj/project.pbxproj
+++ b/QiitaSwiftClient.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		031CF71D2C3D4D9100BAD1C7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 031CF71C2C3D4D9100BAD1C7 /* Preview Assets.xcassets */; };
 		033DDD4F2C56481F009C2419 /* QiitaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033DDD4E2C56481F009C2419 /* QiitaService.swift */; };
 		033DDD512C56490B009C2419 /* QiitaModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033DDD502C56490B009C2419 /* QiitaModel.swift */; };
+		035446C32C6F1BD80048CE82 /* ItemScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035446C22C6F1BD80048CE82 /* ItemScreen.swift */; };
+		0359789D2C70515C0024F13D /* DateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359789C2C70515C0024F13D /* DateFormat.swift */; };
+		03DF82322C6CC3B20014AE52 /* UserScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DF82312C6CC3B20014AE52 /* UserScreen.swift */; };
 		03E9DD7E2C565BE9004F4DF3 /* UserImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E9DD7D2C565BE9004F4DF3 /* UserImage.swift */; };
 		03EE9A422C4CF25900BF3A1A /* PostAccessTokensModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EE9A412C4CF25900BF3A1A /* PostAccessTokensModel.swift */; };
 		03F813D12C44FA900074061D /* UserStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F813D02C44FA900074061D /* UserStateViewModel.swift */; };
@@ -26,6 +29,9 @@
 		031CF71C2C3D4D9100BAD1C7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		033DDD4E2C56481F009C2419 /* QiitaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QiitaService.swift; sourceTree = "<group>"; };
 		033DDD502C56490B009C2419 /* QiitaModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QiitaModel.swift; sourceTree = "<group>"; };
+		035446C22C6F1BD80048CE82 /* ItemScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemScreen.swift; sourceTree = "<group>"; };
+		0359789C2C70515C0024F13D /* DateFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormat.swift; sourceTree = "<group>"; };
+		03DF82312C6CC3B20014AE52 /* UserScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserScreen.swift; sourceTree = "<group>"; };
 		03E9DD7D2C565BE9004F4DF3 /* UserImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImage.swift; sourceTree = "<group>"; };
 		03EE9A412C4CF25900BF3A1A /* PostAccessTokensModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAccessTokensModel.swift; sourceTree = "<group>"; };
 		03F813D02C44FA900074061D /* UserStateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStateViewModel.swift; sourceTree = "<group>"; };
@@ -64,6 +70,7 @@
 		031CF7142C3D4D9000BAD1C7 /* QiitaSwiftClient */ = {
 			isa = PBXGroup;
 			children = (
+				0359789B2C70514D0024F13D /* Utils */,
 				03E9DD7C2C565B89004F4DF3 /* Components */,
 				03EE9A402C4CF22700BF3A1A /* Models */,
 				03F813D62C4803100074061D /* Info.plist */,
@@ -83,6 +90,14 @@
 				031CF71C2C3D4D9100BAD1C7 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		0359789B2C70514D0024F13D /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				0359789C2C70515C0024F13D /* DateFormat.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		03E9DD7C2C565B89004F4DF3 /* Components */ = {
@@ -115,6 +130,8 @@
 			children = (
 				03F813D22C44FB950074061D /* LoginScreen.swift */,
 				03F813D42C4525D60074061D /* HomeScreen.swift */,
+				03DF82312C6CC3B20014AE52 /* UserScreen.swift */,
+				035446C22C6F1BD80048CE82 /* ItemScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -144,6 +161,8 @@
 			dependencies = (
 			);
 			name = QiitaSwiftClient;
+			packageProductDependencies = (
+			);
 			productName = QiitaSwiftClient;
 			productReference = 031CF7122C3D4D9000BAD1C7 /* QiitaSwiftClient.app */;
 			productType = "com.apple.product-type.application";
@@ -172,6 +191,8 @@
 				Base,
 			);
 			mainGroup = 031CF7092C3D4D8F00BAD1C7;
+			packageReferences = (
+			);
 			productRefGroup = 031CF7132C3D4D9000BAD1C7 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -219,13 +240,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				035446C32C6F1BD80048CE82 /* ItemScreen.swift in Sources */,
 				03F813D12C44FA900074061D /* UserStateViewModel.swift in Sources */,
 				03F813D52C4525D60074061D /* HomeScreen.swift in Sources */,
+				03DF82322C6CC3B20014AE52 /* UserScreen.swift in Sources */,
 				03F813D32C44FB950074061D /* LoginScreen.swift in Sources */,
 				03EE9A422C4CF25900BF3A1A /* PostAccessTokensModel.swift in Sources */,
 				03E9DD7E2C565BE9004F4DF3 /* UserImage.swift in Sources */,
 				033DDD4F2C56481F009C2419 /* QiitaService.swift in Sources */,
 				033DDD512C56490B009C2419 /* QiitaModel.swift in Sources */,
+				0359789D2C70515C0024F13D /* DateFormat.swift in Sources */,
 				031CF7162C3D4D9000BAD1C7 /* QiitaSwiftClientApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QiitaSwiftClient/Models/QiitaModel.swift
+++ b/QiitaSwiftClient/Models/QiitaModel.swift
@@ -65,3 +65,37 @@ struct User: Codable {
 }
 
 typealias Items = [Item]
+
+// MARK: - CurrentUser
+
+struct CurrentUser: Codable {
+    let id, name: String
+    let itemsCount: Int
+    let followersCount: Int
+    let description: String?
+    let organization: String?
+    let profileImageURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, description, organization
+        case itemsCount = "items_count"
+        case followersCount = "followers_count"
+        case profileImageURL = "profile_image_url"
+    }
+}
+
+// MARK: - CurrentUser
+
+struct UserItem: Codable {
+    let id, title: String
+    let likesCount: Int
+    let stocksCount: Int
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, title
+        case likesCount = "likes_count"
+        case stocksCount = "stocks_count"
+        case createdAt = "created_at"
+    }
+}

--- a/QiitaSwiftClient/QiitaSwiftClientApp.swift
+++ b/QiitaSwiftClient/QiitaSwiftClientApp.swift
@@ -32,8 +32,7 @@ struct ContentView: View {
                     .tabItem {
                         Label("ホーム", systemImage: "house.fill")
                     }
-                // TODO: ユーザーページ
-                // TODO: 記事ページ
+                // TODO: 検索ページ
             }
         } else {
             LoginScreen()

--- a/QiitaSwiftClient/Screens/HomeScreen.swift
+++ b/QiitaSwiftClient/Screens/HomeScreen.swift
@@ -19,28 +19,31 @@ struct HomeScreen: View {
             ScrollView {
                 LazyVStack(spacing: 6) {
                     ForEach(items, id: \.id) { item in
-                        LazyVGrid(columns: columns) {
-                            UserImage(urlPath: item.user.profileImageURL, height: 50)
-                            VStack(alignment: .leading, spacing: 0) {
-                                Text(item.title)
-                                    .lineLimit(2)
-                                    .bold()
-                                HStack {
-                                    Text(item.user.name == "" ? item.user.id : item.user.name)
-                                        .font(.caption2)
+                        NavigationLink {
+                            ItemScreen(id: item.id, title: item.title)
+                        } label: {
+                            LazyVGrid(columns: columns) {
+                                UserImage(urlPath: item.user.profileImageURL, height: 50)
+                                VStack(alignment: .leading, spacing: 0) {
+                                    Text(item.title)
+                                        .lineLimit(2)
                                         .bold()
-                                    Text(item.createdAt.prefix(10))
-                                        .font(.footnote)
+                                    HStack {
+                                        Text(item.user.name == "" ? item.user.id : item.user.name)
+                                            .font(.caption2)
+                                            .bold()
+                                        Text(item.createdAt.prefix(10))
+                                            .font(.footnote)
+                                    }
                                 }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                Image(systemName: "greaterthan.circle.fill")
+                                    .frame(width: 42, height: 42)
                             }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            Image(systemName: "greaterthan.circle.fill")
-                                .frame(width: 42, height: 42)
                         }
                     }
                 }
                 .padding()
-                .background(Color("Brand"))
             }
             .task {
                 do {
@@ -58,12 +61,12 @@ struct HomeScreen: View {
                 if authenticatedUser != nil {
                     ToolbarItem(placement: .topBarLeading) {
                         Text("Qiita Client")
+                            .fontWeight(.bold)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Menu {
                             NavigationLink("ユーザーページ") {
-                                //                                TODO: 後ほど作成
-                                //                                UserScreen(id: authenticatedUser?.id)
+                                UserScreen(id: authenticatedUser!.id)
                             }
                             Button("ログアウト", role: .destructive) {
                                 viewModel.signOut()
@@ -74,6 +77,8 @@ struct HomeScreen: View {
                     }
                 }
             }
+            .toolbarBackground(Color("Brand"), for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
         }
     }
 }

--- a/QiitaSwiftClient/Screens/ItemScreen.swift
+++ b/QiitaSwiftClient/Screens/ItemScreen.swift
@@ -1,0 +1,117 @@
+//
+//  ItemScreen.swift
+//  QiitaSwiftClient
+//
+//  Created by erika yoshikawa on 2024/08/16.
+//
+
+import SwiftSoup
+import SwiftUI
+
+struct HtmlRender: View {
+    let htmlText: String
+
+    var body: some View {
+        if let nsAttributedString = try? NSAttributedString(
+            data: htmlText.data(using: .utf16)!,
+            options: [.documentType: NSAttributedString.DocumentType.html],
+            documentAttributes: nil
+        ),
+            let attributedString = try? AttributedString(nsAttributedString, including: \.uiKit)
+        {
+            Text(attributedString)
+        } else {
+            Text(htmlText)
+        }
+    }
+}
+
+struct ItemScreen: View {
+    let id: String
+    let title: String
+
+    @State private var item: Item? = nil
+    @State private var itemBody: String = ""
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if item != nil {
+                    HStack {
+                        NavigationLink {
+                            UserScreen(id: item!.user.id)
+                        } label: {
+                            HStack {
+                                UserImage(urlPath: item!.user.profileImageURL, height: 25)
+                                Text("@\(item!.user.name == "" ? item!.user.id : item!.user.name)")
+                            }
+                        }
+                        Spacer()
+                        Text(item!.createdAt)
+                    }
+                    .padding()
+                    Text(item!.title)
+                        .font(.title)
+                        .fontWeight(.bold)
+                    if item!.tags.isEmpty != true {
+                        ScrollView(.horizontal) {
+                            HStack {
+                                ForEach(item!.tags, id: \.name) { tag in
+                                    Text(tag.name)
+                                        .font(.footnote)
+                                        .padding()
+                                        .background(RoundedRectangle(cornerRadius: 25).fill(.green))
+                                }
+                            }
+                            .padding()
+                        }
+                    }
+//                    HtmlRender(htmlText: item!.renderedBody)
+                    HtmlRender(htmlText:
+                        """
+                        <html>
+                        <style>
+                          h1, h2, h3 {
+                            margin-bottom: 12px;
+                        }
+                          h1, h2, h3, p {
+                            line-height: 2.5;
+                          }
+                        </style>
+                        <body>
+                        \(item!.renderedBody)
+                        </body>
+                        </html>
+                        """)
+                        .padding(12)
+                        .background(Color.green)
+
+                } else {
+                    VStack {
+                        ProgressView()
+                    }
+                }
+            }
+            .task {
+                do {
+                    let fetchedItem = try await QiitaService().getItem(itemId: id)
+                    item = fetchedItem
+//                    let doc: Document = try SwiftSoup.parse(item!.renderedBody)
+//                    itemBody = try doc.text()
+//                } catch let Exception.Error(type, message) {
+//                    print(message)
+                } catch {
+                    print("items not found")
+                }
+            }
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+//            .background(Color("Brand"))
+        }
+    }
+}
+
+//
+// #Preview {
+//    ItemScreen()
+// }

--- a/QiitaSwiftClient/Screens/UserScreen.swift
+++ b/QiitaSwiftClient/Screens/UserScreen.swift
@@ -1,0 +1,94 @@
+//
+//  UserScreen.swift
+//  QiitaSwiftClient
+//
+//  Created by erika yoshikawa on 2024/08/14.
+//
+
+import SwiftUI
+
+struct UserScreen: View {
+    let id: String
+
+    @State private var user: CurrentUser? = nil
+    @State private var items: [UserItem] = []
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                if user == nil {
+                    Text("ユーザーが見つかりません")
+                } else {
+                    VStack {
+                        UserImage(urlPath: user!.profileImageURL, height: 50)
+                        Text("@\(user!.id)")
+                            .fontWeight(.semibold)
+                        Text(user!.description ?? "ユーザー説明がありません")
+                            .padding()
+                        HStack {
+                            Text("\(user!.itemsCount)投稿")
+                            Text("\(user!.followersCount)フォロワー")
+                        }
+                    }
+                    .padding(6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 25.0)
+                            .fill(.gray.opacity(0.3))
+                    )
+                    Divider()
+                    VStack {
+                        Text("最新の投稿一覧")
+                        ScrollView {
+                            LazyVStack(spacing: 6) {
+                                ForEach(items, id: \.id) { item in
+                                    NavigationLink(destination: {
+                                        ItemScreen(id: id, title: item.title)
+                                    }, label: {
+                                        VStack(alignment: .leading) {
+                                            Text(item.title)
+                                                .fontWeight(.bold)
+                                            Text(formatDateString(isoString: item.createdAt))
+                                                .font(.footnote)
+                                            HStack {
+                                                HStack {
+                                                    Label("\(item.likesCount)", systemImage: "heart.fill")
+                                                    Label("\(item.stocksCount)", systemImage: "tray.fill")
+                                                }
+                                                Spacer()
+                                            }
+                                        }
+                                        .frame(minHeight: 50)
+                                    })
+                                    .tint(Color.primary)
+                                    .padding(6)
+                                    .background(.gray)
+                                }
+                            }
+                        }
+                        .padding()
+                    }
+                    .padding(6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 25.0)
+                            .fill(.gray.opacity(0.3))
+                    )
+                }
+            }
+            .task {
+                do {
+                    let fetchedUser = try await QiitaService().getUser(userId: id)
+                    user = fetchedUser
+                    let fetchedItems = try await QiitaService().getUserItems(userId: id)
+                    items = fetchedItems
+                } catch {
+                    print("user not found")
+                }
+            }
+        }
+    }
+}
+
+//
+// #Preview {
+//    UserScreen()
+// }

--- a/QiitaSwiftClient/Services/QiitaService.swift
+++ b/QiitaSwiftClient/Services/QiitaService.swift
@@ -53,4 +53,55 @@ struct QiitaService {
 
         _ = try await URLSession.shared.data(for: request)
     }
+
+    func getUser(userId: String) async throws -> CurrentUser {
+        guard let url = URL(string: "https://qiita.com/api/v2/users/\(userId)") else {
+            throw URLError(.badURL)
+        }
+        guard let token = UserDefaults.standard.value(forKey: "AccessToken") else {
+            print("not found token")
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let currentUser = try JSONDecoder().decode(CurrentUser.self, from: data)
+        return currentUser
+    }
+
+    func getItem(itemId: String) async throws -> Item {
+        guard let url = URL(string: "https://qiita.com/api/v2/items/\(itemId)") else {
+            throw URLError(.badURL)
+        }
+        guard let token = UserDefaults.standard.value(forKey: "AccessToken") else {
+            print("not found token")
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let item = try JSONDecoder().decode(Item.self, from: data)
+        return item
+    }
+
+    func getUserItems(userId: String) async throws -> [UserItem] {
+        guard let url = URL(string: "https://qiita.com/api/v2/users/\(userId)/items?page=1&per_page=20") else {
+            throw URLError(.badURL)
+        }
+        guard let token = UserDefaults.standard.value(forKey: "AccessToken") else {
+            print("not found token")
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let items = try JSONDecoder().decode([UserItem].self, from: data)
+        return items
+    }
 }

--- a/QiitaSwiftClient/Utils/DateFormat.swift
+++ b/QiitaSwiftClient/Utils/DateFormat.swift
@@ -1,0 +1,21 @@
+//
+//  DateFormat.swift
+//  QiitaSwiftClient
+//
+//  Created by erika yoshikawa on 2024/08/17.
+//
+
+import Foundation
+
+// ref: https://qiita.com/antk/items/74ebd6110f94b6843f6a
+func formatDateString(isoString: String) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+
+    guard let date = formatter.date(from: isoString) else {
+        return "日付なし"
+    }
+    formatter.dateFormat = "yyyy年MM月dd日"
+    return formatter.string(from: date)
+}


### PR DESCRIPTION
# 実装したこと

- 記事・ユーザー画面の作成
- Qiitaログインしないとホーム画面が見れない画面フローを作成

## 備考

- HTMLの表示に当初Swiftsoupを検討していたが、標準のNSAttributedStringで代用でき不要だったため未使用。